### PR TITLE
fixed order of asks prices in getOrderBook to be consistent with binance

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -62,7 +62,12 @@ export class KunaApiClient {
         const {data}: AxiosResponse = await this.axiosClient.get(`/depth?market=${market}`);
 
         this.debug('getOrderBook(${market)=', data);
-
+        
+        //kuna returns asks prices in descending order, that is not expected and different from binance response
+        data.asks.sort(function (a, b) {
+            if (+a[0] === +b[0]) return 0;
+            else return (+a[0] < +b[0]) ? -1 : 1;
+        })
         return data;
     }
 
@@ -167,7 +172,7 @@ export class KunaApiClient {
         const assortedParams = chain(params).toPairs().sortBy(0).fromPairs().value();
 
         const queryString = `${httpVerb}|${u.pathname}|${qs.stringify(assortedParams)}`;
-
+        
         return crypto.createHmac('sha256', this.secretKey)
             .update(queryString)
             .digest('hex');

--- a/test/api-client.test.js
+++ b/test/api-client.test.js
@@ -75,6 +75,9 @@ describe('api-client.test.js', function () {
             assert.equal("timestamp" in response, true);
             assert.equal("bids" in response, true);
             assert.equal("asks" in response, true);
+            //we need to verify that asks in ascending order
+            expect(+response["asks"][0][0]).toBeLessThan(+response["asks"][1][0]);
+            expect(+response["bids"][0][0]).toBeGreaterThan(+response["bids"][1][0]);
             done();
           })
           .catch(function (error) {
@@ -155,18 +158,17 @@ describe('api-client.test.js', function () {
                 assert.equal(typeof response, "object");
                 expect(response2.length).toBeGreaterThan(0);
                 // console.log("user orders=", response);
+                kuna.cancelOrder(response.id).then(function (response2) {
+                    expect(response2.id).toBeGreaterThan(0);
+                  })
+                  .catch(function (error) {
+                    done(error);
+                    console.log(error.response.data);
+                  });
               })
               .catch(function (error) {
                 console.log(error.response.data);
                 done(error);
-              });
-
-            kuna.cancelOrder(response.id).then(function (response2) {
-                expect(response2.id).toBeGreaterThan(0);
-              })
-              .catch(function (error) {
-                done(error);
-                console.log(error.response.data);
               });
           })
           .catch(function (error) {


### PR DESCRIPTION
* fixed order of asks prices in getOrderBook to be consistent with binance
* fixed unit test as it gave tonce already used error. Cancel order
should wait for previous request to complete